### PR TITLE
Preserve play order across page refresh

### DIFF
--- a/app/deck/[deckId]/play/page.tsx
+++ b/app/deck/[deckId]/play/page.tsx
@@ -11,22 +11,12 @@ import {
     useMissedCardsForDeckInTimeframe
 } from '@/hooks/queryHooks';
 import { useAuth } from '@/context/useAuth';
-import { ReviewResult, Card } from '@/types';
+import { Card } from '@/types';
 import CardReviewer from '@/components/CardReviewer';
 import type { AnswerData } from '@/components/answer-modes/AnswerModeDispatcher';
 import Spinner from '@/components/Spinner';
 import PageHeader from '@/components/PageHeader';
-
-// Helper function to shuffle array
-function shuffleArray<T>(array: T[]): T[] {
-    if (!array || array.length === 0) return [];
-    const shuffled = [...array];
-    for (let i = shuffled.length - 1; i > 0; i--) {
-        const j = Math.floor(Math.random() * (i + 1));
-        [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
-    }
-    return shuffled;
-}
+import { getOrCreatePlayOrder, reshuffleAndSave, type PlayOrderKey } from '@/lib/playOrder';
 
 function PlayDeckPageContent() {
     const params = useParams();
@@ -45,18 +35,22 @@ function PlayDeckPageContent() {
             timeframeDaysParsed = parsed;
         }
     }
+
     const desiredCardIndexFromParam = useMemo(() => {
         if (!cardParamRaw) return 0;
         const parsed = parseInt(cardParamRaw, 10);
-        if (isNaN(parsed) || parsed < 1) {
-            return 0;
-        }
+        if (isNaN(parsed) || parsed < 1) return 0;
         return parsed - 1;
     }, [cardParamRaw]);
 
+    const orderKeyParams = useMemo<PlayOrderKey>(() => ({
+        deckId,
+        strategy: playStrategy,
+        timeframe: timeframeDaysParsed,
+    }), [deckId, playStrategy, timeframeDaysParsed]);
+
     const { token } = useAuth();
 
-    // Conditional hooks
     const allCardsQuery = useDeckCards(deckId);
     const missedCardsQuery = useMissedCardsForDeckInTimeframe({
         deckId,
@@ -66,9 +60,7 @@ function PlayDeckPageContent() {
     });
 
     const cardsToUse = useMemo(() => {
-        if (playStrategy === 'missedInTimeframe') {
-            return missedCardsQuery.data;
-        }
+        if (playStrategy === 'missedInTimeframe') return missedCardsQuery.data;
         return allCardsQuery.data;
     }, [playStrategy, allCardsQuery.data, missedCardsQuery.data]);
 
@@ -83,13 +75,12 @@ function PlayDeckPageContent() {
 
     useEffect(() => {
         if (cardsToUse && cardsToUse.length > 0) {
-            const sequence = shuffleArray(cardsToUse);
-            setReviewSequence(sequence);
-        } else if (!isLoadingCards) { // Only reset if not loading and cardsToUse is empty/undefined
+            setReviewSequence(getOrCreatePlayOrder(cardsToUse, orderKeyParams));
+        } else if (!isLoadingCards) {
             setReviewSequence([]);
             setCurrentCardIndex(0);
         }
-    }, [cardsToUse, isLoadingCards]);
+    }, [cardsToUse, isLoadingCards, orderKeyParams]);
 
     useEffect(() => {
         if (reviewSequence.length === 0) return;
@@ -104,16 +95,15 @@ function PlayDeckPageContent() {
         const nextCardParam = String(currentCardNumber);
         if (cardParamRaw === nextCardParam) return;
 
-        const params = new URLSearchParams(searchParams.toString());
-        params.set('card', nextCardParam);
-        router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+        const p = new URLSearchParams(searchParams.toString());
+        p.set('card', nextCardParam);
+        router.replace(`${pathname}?${p.toString()}`, { scroll: false });
     }, [cardParamRaw, currentCardIndex, reviewSequence.length, router, pathname, searchParams]);
 
     const handleReview = (data: AnswerData) => {
-        if (!reviewSequence || reviewSequence.length === 0 || deckId === undefined || createReviewMutation.isPending) return;
-        const safeIndex = currentCardIndex;
-        if (safeIndex >= reviewSequence.length) return;
-        const currentCard = reviewSequence[safeIndex];
+        if (reviewSequence.length === 0 || deckId === undefined || createReviewMutation.isPending) return;
+        if (currentCardIndex >= reviewSequence.length) return;
+        const currentCard = reviewSequence[currentCardIndex];
 
         createReviewMutation.mutate({
             cardId: currentCard.id,
@@ -133,15 +123,15 @@ function PlayDeckPageContent() {
     };
 
     const handlePlayAgain = () => {
-        if (cardsToUse && cardsToUse.length > 0) {
-            const params = new URLSearchParams(searchParams.toString());
-            params.set('card', '1');
-            router.replace(`${pathname}?${params.toString()}`, { scroll: false });
-            const sequence = shuffleArray(cardsToUse);
-            setReviewSequence(sequence);
-        }
+        if (!cardsToUse || cardsToUse.length === 0) return;
+        const sequence = reshuffleAndSave(cardsToUse, orderKeyParams);
+        setReviewSequence(sequence);
         setCurrentCardIndex(0);
-    } // Play again re-shuffles the currently loaded set (all or missed)
+
+        const p = new URLSearchParams(searchParams.toString());
+        p.set('card', '1');
+        router.replace(`${pathname}?${p.toString()}`, { scroll: false });
+    };
 
     const isLoading = isLoadingCards || isLoadingDeck;
 
@@ -153,7 +143,7 @@ function PlayDeckPageContent() {
         return <div className="text-center text-red-500 p-4">Invalid timeframe specified for missed cards strategy.</div>;
     }
 
-    if (isLoading && (!deck)) { // Only wait for deck if cards are also loading or not yet determined
+    if (isLoading && !deck) {
         return (
             <div className="flex justify-center items-center py-10">
                 <Spinner /> <span className="ml-2 text-gray-500">Loading deck...</span>
@@ -165,8 +155,7 @@ function PlayDeckPageContent() {
         return <div className="text-center text-red-500 p-4 bg-red-50 rounded border border-red-200">Error loading cards: {(cardsError as Error).message || 'Unknown error'}.</div>;
     }
 
-    // After loading and error checks, if no cards, show specific message
-    if (!isLoading && (!reviewSequence || reviewSequence.length === 0)) {
+    if (!isLoading && reviewSequence.length === 0) {
         const emptyMessage = playStrategy === 'missedInTimeframe'
             ? `No cards found that were missed in the last ${timeframeDaysParsed} day(s).`
             : 'This deck is empty.';
@@ -180,10 +169,7 @@ function PlayDeckPageContent() {
         );
     }
 
-    // If reviewSequence is still undefined/empty after all checks (should be caught above, but as a fallback)
-    if (!reviewSequence) return <div className="text-center text-gray-500">Preparing cards...</div>;
-
-    if (currentCardIndex >= reviewSequence.length && reviewSequence.length > 0) { // Added check for length > 0 to avoid flash of finished when loading
+    if (currentCardIndex >= reviewSequence.length && reviewSequence.length > 0) {
         return (
             <div className="text-center space-y-6 py-10">
                 <p className="text-2xl font-semibold text-green-600">Deck finished!</p>
@@ -201,23 +187,17 @@ function PlayDeckPageContent() {
     }
 
     const currentCard = reviewSequence[currentCardIndex];
-    if (!currentCard && !isLoading) { // Only show loading card if not generally loading
-        return <div className="text-center text-gray-500">Loading card...</div>;
-    }
-    if (!currentCard && isLoading) { // If generally loading and no current card yet, show main spinner
+    if (!currentCard) {
         return (
             <div className="flex justify-center items-center py-10">
                 <Spinner /> <span className="ml-2 text-gray-500">Loading cards...</span>
             </div>
         );
     }
-    if (!currentCard) return null; // Final fallback
 
-
-    let strategyTitleSegment = '';
-    if (playStrategy === 'missedInTimeframe') {
-        strategyTitleSegment = `(Missed in last ${timeframeDaysParsed} days) `;
-    }
+    const strategyTitleSegment = playStrategy === 'missedInTimeframe'
+        ? `(Missed in last ${timeframeDaysParsed} days)`
+        : '';
 
     const totalCards = reviewSequence.length;
 
@@ -231,7 +211,7 @@ function PlayDeckPageContent() {
                     <>
                         {strategyTitleSegment && (
                             <span className="text-sm text-gray-400 whitespace-nowrap">
-                                {strategyTitleSegment.trim()}
+                                {strategyTitleSegment}
                             </span>
                         )}
                         <span className="text-sm font-medium text-gray-500 whitespace-nowrap">

--- a/app/lib/playOrder.ts
+++ b/app/lib/playOrder.ts
@@ -1,0 +1,84 @@
+function shuffleArray<T>(array: T[]): T[] {
+    const shuffled = [...array];
+    for (let i = shuffled.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+    }
+    return shuffled;
+}
+
+export interface PlayOrderKey {
+    deckId?: string;
+    strategy: string;
+    deckIds?: string[];
+    timeframe?: number;
+}
+
+function buildStorageKey(params: PlayOrderKey): string {
+    if (params.deckId) {
+        let key = `play-order:deck:${params.deckId}:${params.strategy}`;
+        if (params.timeframe) key += `:${params.timeframe}`;
+        return key;
+    }
+    const decksPart = params.deckIds ? [...params.deckIds].sort().join(',') : 'all';
+    return `play-order:global:${params.strategy}:${decksPart}`;
+}
+
+/**
+ * Returns cards in a stable shuffled order. If a matching order exists
+ * in localStorage (same set of card IDs), it reuses that order.
+ * Otherwise it shuffles fresh and persists the new order.
+ */
+export function getOrCreatePlayOrder<T extends { id: string }>(
+    cards: T[],
+    keyParams: PlayOrderKey,
+): T[] {
+    if (cards.length === 0) return [];
+
+    const key = buildStorageKey(keyParams);
+    const currentIds = new Set(cards.map(c => c.id));
+
+    try {
+        const stored = localStorage.getItem(key);
+        if (stored) {
+            const savedIds: string[] = JSON.parse(stored);
+            const savedSet = new Set(savedIds);
+
+            if (savedSet.size === currentIds.size && savedIds.every(id => currentIds.has(id))) {
+                const cardMap = new Map(cards.map(c => [c.id, c]));
+                return savedIds.map(id => cardMap.get(id)!);
+            }
+        }
+    } catch {
+        // localStorage unavailable or data corrupted — fall through to fresh shuffle
+    }
+
+    return reshuffleAndSave(cards, keyParams);
+}
+
+/**
+ * Shuffles cards into a new random order, saves to localStorage,
+ * and returns the new sequence.
+ */
+export function reshuffleAndSave<T extends { id: string }>(
+    cards: T[],
+    keyParams: PlayOrderKey,
+): T[] {
+    const shuffled = shuffleArray(cards);
+    const key = buildStorageKey(keyParams);
+    try {
+        localStorage.setItem(key, JSON.stringify(shuffled.map(c => c.id)));
+    } catch {
+        // ignore storage errors
+    }
+    return shuffled;
+}
+
+export function clearPlayOrder(keyParams: PlayOrderKey): void {
+    const key = buildStorageKey(keyParams);
+    try {
+        localStorage.removeItem(key);
+    } catch {
+        // ignore
+    }
+}

--- a/app/play/page.tsx
+++ b/app/play/page.tsx
@@ -1,26 +1,17 @@
 'use client';
 
-import React, { Suspense } from 'react';
+import React, { Suspense, useState, useEffect, useMemo } from 'react';
 import { useSearchParams, useRouter, usePathname } from 'next/navigation';
 import Link from 'next/link';
 import Button from '@/components/Button';
 import { useCardsForReview, useCreateReviewEventMutation } from '@/hooks/queryHooks';
-import { ReviewResult, Card } from '@/types';
+import { Card } from '@/types';
 import CardReviewer from '@/components/CardReviewer';
 import type { AnswerData } from '@/components/answer-modes/AnswerModeDispatcher';
 import Spinner from '@/components/Spinner';
 import PageHeader from '@/components/PageHeader';
 import { useAuth } from '@/context/useAuth';
-
-// Helper function to shuffle array (if not already in a utils file)
-function shuffleArray<T>(array: T[]): T[] {
-    const shuffled = [...array];
-    for (let i = shuffled.length - 1; i > 0; i--) {
-        const j = Math.floor(Math.random() * (i + 1));
-        [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
-    }
-    return shuffled;
-}
+import { getOrCreatePlayOrder, reshuffleAndSave, clearPlayOrder, type PlayOrderKey } from '@/lib/playOrder';
 
 function PlayPageContent() {
     const searchParams = useSearchParams();
@@ -35,66 +26,65 @@ function PlayPageContent() {
 
     const strategy = (strategyParam === 'random' || strategyParam === 'missedFirst') ? strategyParam : 'random';
     const limit = parseInt(limitParam || '20', 10);
-    const selectedDeckIds = deckIdsParam ? deckIdsParam.split(',').filter(id => id.trim() !== '') : undefined; // New: parse deckIds
+    const selectedDeckIds = deckIdsParam ? deckIdsParam.split(',').filter(id => id.trim() !== '') : undefined;
+
+    const orderKeyParams = useMemo<PlayOrderKey>(() => ({
+        strategy,
+        deckIds: selectedDeckIds,
+    }), [strategy, selectedDeckIds]);
 
     const { data: cards, isLoading: isLoadingCards, error: cardsError, refetch } = useCardsForReview({
-        // deckId: undefined, // Explicitly not using single deckId here when deckIds might be present
-        deckIds: selectedDeckIds, // New: pass selectedDeckIds
+        deckIds: selectedDeckIds,
         limit,
         strategy,
-        token: token ?? undefined, // Coalesce null to undefined
-        enabled: !isLoadingAuth && !!token, // Only enable if auth is loaded and token exists
+        token: token ?? undefined,
+        enabled: !isLoadingAuth && !!token,
     });
 
     const createReviewMutation = useCreateReviewEventMutation();
 
-    const [currentCardIndex, setCurrentCardIndex] = React.useState<number>(0);
-    const [reviewSequence, setReviewSequence] = React.useState<Card[]>([]);
+    const [currentCardIndex, setCurrentCardIndex] = useState<number>(0);
+    const [reviewSequence, setReviewSequence] = useState<Card[]>([]);
 
-    const desiredCardIndexFromParam = React.useMemo(() => {
+    const desiredCardIndexFromParam = useMemo(() => {
         if (!cardParamRaw) return 0;
         const parsed = parseInt(cardParamRaw, 10);
-        if (isNaN(parsed) || parsed < 1) {
-            return 0;
-        }
+        if (isNaN(parsed) || parsed < 1) return 0;
         return parsed - 1;
     }, [cardParamRaw]);
 
-    React.useEffect(() => {
+    useEffect(() => {
         if (cards && cards.length > 0) {
-            // The hook already implements strategies like missedFirst or random sampling.
-            // Shuffling here might be redundant if strategy is random, but okay for consistency or if strategy changes.
-            setReviewSequence(shuffleArray(cards));
+            setReviewSequence(getOrCreatePlayOrder(cards, orderKeyParams));
         } else {
             setReviewSequence([]);
             setCurrentCardIndex(0);
         }
-    }, [cards]);
+    }, [cards, orderKeyParams]);
 
-    React.useEffect(() => {
+    useEffect(() => {
         if (reviewSequence.length === 0) return;
         const normalizedIndex = Math.max(0, Math.min(reviewSequence.length - 1, desiredCardIndexFromParam));
         setCurrentCardIndex(prev => (prev === normalizedIndex ? prev : normalizedIndex));
     }, [desiredCardIndexFromParam, reviewSequence]);
 
-    React.useEffect(() => {
+    useEffect(() => {
         if (reviewSequence.length === 0) return;
         const totalCards = reviewSequence.length;
         const currentCardNumber = Math.min(currentCardIndex + 1, totalCards);
         const nextCardParam = String(currentCardNumber);
         if (cardParamRaw === nextCardParam) return;
 
-        const params = new URLSearchParams(searchParams.toString());
-        params.set('card', nextCardParam);
-        router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+        const p = new URLSearchParams(searchParams.toString());
+        p.set('card', nextCardParam);
+        router.replace(`${pathname}?${p.toString()}`, { scroll: false });
     }, [cardParamRaw, currentCardIndex, reviewSequence.length, router, pathname, searchParams]);
 
     const handleReview = (data: AnswerData) => {
-        if (!reviewSequence || reviewSequence.length === 0 || createReviewMutation.isPending) return;
-        const safeIndex = currentCardIndex;
-        if (safeIndex >= reviewSequence.length) return;
+        if (reviewSequence.length === 0 || createReviewMutation.isPending) return;
+        if (currentCardIndex >= reviewSequence.length) return;
 
-        const currentCard = reviewSequence[safeIndex];
+        const currentCard = reviewSequence[currentCardIndex];
 
         createReviewMutation.mutate({
             cardId: currentCard.id,
@@ -114,11 +104,14 @@ function PlayPageContent() {
     };
 
     const handlePlayAgain = () => {
-        const params = new URLSearchParams(searchParams.toString());
-        params.set('card', '1');
-        router.replace(`${pathname}?${params.toString()}`, { scroll: false });
-        refetch(); // Refetch cards based on the same criteria
+        clearPlayOrder(orderKeyParams);
         setCurrentCardIndex(0);
+
+        const p = new URLSearchParams(searchParams.toString());
+        p.set('card', '1');
+        router.replace(`${pathname}?${p.toString()}`, { scroll: false });
+
+        refetch();
     };
 
     if (isLoadingAuth || (isLoadingCards && !cards)) {
@@ -143,10 +136,10 @@ function PlayPageContent() {
         return <div className="text-center text-red-500 p-4 bg-red-50 rounded border border-red-200">Error loading cards: {(cardsError as Error).message || 'Unknown error'}.</div>;
     }
 
-    if (!isLoadingCards && (!reviewSequence || reviewSequence.length === 0)) {
+    if (!isLoadingCards && reviewSequence.length === 0) {
         return (
             <div className="text-center space-y-6 py-10">
-                <p className="text-lg text-gray-500">No cards found for this session.</p>
+                <p className="text-lg text-gray-500">No cards found for this play through.</p>
                 <p className="text-sm text-gray-400">
                     Try adjusting your strategy, selecting different decks, or adding more cards.
                 </p>
@@ -185,12 +178,10 @@ function PlayPageContent() {
 
     const currentCard = reviewSequence[currentCardIndex];
     if (!currentCard) {
-        // This case should ideally not be reached if reviewSequence is managed properly
         return <div className="text-center text-gray-500 py-10">Loading card...</div>;
     }
 
-    const sessionTitle = selectedDeckIds ? "Playing Selected Decks" : "Playing All Decks";
-
+    const sessionTitle = selectedDeckIds ? 'Playing Selected Decks' : 'Playing All Decks';
     const totalCards = reviewSequence.length;
 
     return (
@@ -220,7 +211,6 @@ function PlayPageContent() {
     );
 }
 
-// Wrap with Suspense because useSearchParams() needs it.
 export default function PlayPage() {
     return (
         <Suspense fallback={<div className="flex justify-center items-center min-h-[300px]"><Spinner /><p className="ml-2">Loading play session...</p></div>}>


### PR DESCRIPTION
## Summary

- Refreshing a play page no longer reshuffles the deck — the card order is saved to `localStorage` and restored on reload, so `?card=7` still points to the same card.
- New `app/lib/playOrder.ts` utility with `getOrCreatePlayOrder`, `reshuffleAndSave`, and `clearPlayOrder` functions, keyed by deck ID + strategy (+ timeframe for missed-cards mode).
- "Play Again" forces a fresh shuffle and saves the new order.
- Cleaned up both play pages: removed duplicated `shuffleArray`, unused `ReviewResult` import, dead `if (!reviewSequence)` check, redundant null-check branches, and stale comments.

## Test plan

- [ ] Open a deck play page, note the card order and position
- [ ] Refresh the page — should land on the same card in the same order
- [ ] Advance a few cards, refresh — position and order preserved
- [ ] Click "Play Again" — should get a new shuffled order
- [ ] Test with "missed in timeframe" strategy — same preservation behavior
- [ ] Test global `/play` page with the same refresh scenarios
- [ ] Add or remove a card from the deck, then refresh the play page — should detect the mismatch and reshuffle

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces localStorage-backed ordering logic that affects core review navigation; risk is mainly around mismatched/stale stored IDs or SSR/client-only edge cases on refresh.
> 
> **Overview**
> **Play sessions now preserve card order across refresh/navigation.** Both deck play (`app/deck/[deckId]/play/page.tsx`) and global play (`app/play/page.tsx`) switch from per-load shuffling to a stable order restored from `localStorage`, keeping `?card=` pointing at the same card.
> 
> Adds `app/lib/playOrder.ts` to manage persisted shuffle state (`getOrCreatePlayOrder`, `reshuffleAndSave`, `clearPlayOrder`) keyed by deck/strategy (and timeframe or selected deck IDs). “Play Again” now forces a new order by reshuffling/saving (deck play) or clearing the stored order and refetching (global play), alongside minor cleanup of unused imports and redundant checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81148d94546be4d7cc8c02d1e83a9c2db7a125da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->