### PR TITLE
[codex] Randomize deck play sessions

### DIFF
--- a/app/deck/[deckId]/play/page.tsx
+++ b/app/deck/[deckId]/play/page.tsx
@@ -27,6 +27,7 @@ function PlayDeckPageContent() {
     const playStrategy = (searchParams.get('strategy') ?? undefined) === 'missedInTimeframe' ? 'missedInTimeframe' : 'all';
     const timeframeParam = searchParams.get('timeframe') ?? undefined;
     const cardParamRaw = searchParams.get('card');
+    const sessionId = searchParams.get('session') ?? undefined;
 
     let timeframeDaysParsed: number | undefined = undefined;
     if (timeframeParam) {
@@ -47,7 +48,8 @@ function PlayDeckPageContent() {
         deckId,
         strategy: playStrategy,
         timeframe: timeframeDaysParsed,
-    }), [deckId, playStrategy, timeframeDaysParsed]);
+        sessionId,
+    }), [deckId, playStrategy, timeframeDaysParsed, sessionId]);
 
     const { token } = useAuth();
 
@@ -70,35 +72,39 @@ function PlayDeckPageContent() {
     const createReviewMutation = useCreateReviewEventMutation();
     const { data: deck, isLoading: isLoadingDeck } = useDeck(deckId);
 
-    const [currentCardIndex, setCurrentCardIndex] = useState<number>(0);
+    const [currentCardIndex, setCurrentCardIndex] = useState<number>(desiredCardIndexFromParam);
     const [reviewSequence, setReviewSequence] = useState<Card[]>([]);
 
     useEffect(() => {
+        if (!deckId || sessionId) return;
+
+        const p = new URLSearchParams(searchParams.toString());
+        p.set('session', typeof crypto.randomUUID === 'function' ? crypto.randomUUID() : String(Date.now()));
+        p.set('card', '1');
+        router.replace(`${pathname}?${p.toString()}`, { scroll: false });
+    }, [deckId, sessionId, router, pathname, searchParams]);
+
+    useEffect(() => {
+        if (!sessionId) return;
         if (cardsToUse && cardsToUse.length > 0) {
             setReviewSequence(getOrCreatePlayOrder(cardsToUse, orderKeyParams));
         } else if (!isLoadingCards) {
             setReviewSequence([]);
             setCurrentCardIndex(0);
         }
-    }, [cardsToUse, isLoadingCards, orderKeyParams]);
+    }, [cardsToUse, isLoadingCards, orderKeyParams, sessionId]);
 
     useEffect(() => {
         if (reviewSequence.length === 0) return;
-        const normalizedIndex = Math.max(0, Math.min(reviewSequence.length - 1, desiredCardIndexFromParam));
+        const normalizedIndex = Math.max(0, Math.min(reviewSequence.length, desiredCardIndexFromParam));
         setCurrentCardIndex(prev => (prev === normalizedIndex ? prev : normalizedIndex));
-    }, [desiredCardIndexFromParam, reviewSequence]);
-
-    useEffect(() => {
-        if (reviewSequence.length === 0) return;
-        const totalCards = reviewSequence.length;
-        const currentCardNumber = Math.min(currentCardIndex + 1, totalCards);
-        const nextCardParam = String(currentCardNumber);
-        if (cardParamRaw === nextCardParam) return;
+        const normalizedCardParam = String(normalizedIndex + 1);
+        if (cardParamRaw === normalizedCardParam) return;
 
         const p = new URLSearchParams(searchParams.toString());
-        p.set('card', nextCardParam);
+        p.set('card', normalizedCardParam);
         router.replace(`${pathname}?${p.toString()}`, { scroll: false });
-    }, [cardParamRaw, currentCardIndex, reviewSequence.length, router, pathname, searchParams]);
+    }, [cardParamRaw, desiredCardIndexFromParam, reviewSequence.length, router, pathname, searchParams]);
 
     const handleReview = (data: AnswerData) => {
         if (reviewSequence.length === 0 || deckId === undefined || createReviewMutation.isPending) return;
@@ -114,7 +120,12 @@ function PlayDeckPageContent() {
             user_answer: data.user_answer,
         }, {
             onSuccess: () => {
-                setCurrentCardIndex(currentCardIndex + 1);
+                const nextCardIndex = currentCardIndex + 1;
+                setCurrentCardIndex(nextCardIndex);
+
+                const p = new URLSearchParams(searchParams.toString());
+                p.set('card', String(nextCardIndex + 1));
+                router.replace(`${pathname}?${p.toString()}`, { scroll: false });
             },
             onError: (err) => {
                 alert(`Failed to record review: ${err.message}`);
@@ -124,11 +135,19 @@ function PlayDeckPageContent() {
 
     const handlePlayAgain = () => {
         if (!cardsToUse || cardsToUse.length === 0) return;
-        const sequence = reshuffleAndSave(cardsToUse, orderKeyParams);
+
+        const nextSessionId = typeof crypto.randomUUID === 'function' ? crypto.randomUUID() : String(Date.now());
+        const nextOrderKeyParams = {
+            ...orderKeyParams,
+            sessionId: nextSessionId,
+        };
+        const sequence = reshuffleAndSave(cardsToUse, nextOrderKeyParams);
+
         setReviewSequence(sequence);
         setCurrentCardIndex(0);
 
         const p = new URLSearchParams(searchParams.toString());
+        p.set('session', nextSessionId);
         p.set('card', '1');
         router.replace(`${pathname}?${p.toString()}`, { scroll: false });
     };
@@ -143,7 +162,7 @@ function PlayDeckPageContent() {
         return <div className="text-center text-red-500 p-4">Invalid timeframe specified for missed cards strategy.</div>;
     }
 
-    if (isLoading && !deck) {
+    if (!sessionId || (isLoading && !deck)) {
         return (
             <div className="flex justify-center items-center py-10">
                 <Spinner /> <span className="ml-2 text-gray-500">Loading deck...</span>

--- a/app/lib/playOrder.ts
+++ b/app/lib/playOrder.ts
@@ -12,16 +12,20 @@ export interface PlayOrderKey {
     strategy: string;
     deckIds?: string[];
     timeframe?: number;
+    sessionId?: string;
 }
 
 function buildStorageKey(params: PlayOrderKey): string {
     if (params.deckId) {
         let key = `play-order:deck:${params.deckId}:${params.strategy}`;
         if (params.timeframe) key += `:${params.timeframe}`;
+        if (params.sessionId) key += `:${params.sessionId}`;
         return key;
     }
     const decksPart = params.deckIds ? [...params.deckIds].sort().join(',') : 'all';
-    return `play-order:global:${params.strategy}:${decksPart}`;
+    let key = `play-order:global:${params.strategy}:${decksPart}`;
+    if (params.sessionId) key += `:${params.sessionId}`;
+    return key;
 }
 
 /**

--- a/app/play/page.tsx
+++ b/app/play/page.tsx
@@ -11,7 +11,7 @@ import type { AnswerData } from '@/components/answer-modes/AnswerModeDispatcher'
 import Spinner from '@/components/Spinner';
 import PageHeader from '@/components/PageHeader';
 import { useAuth } from '@/context/useAuth';
-import { getOrCreatePlayOrder, reshuffleAndSave, clearPlayOrder, type PlayOrderKey } from '@/lib/playOrder';
+import { getOrCreatePlayOrder, clearPlayOrder, type PlayOrderKey } from '@/lib/playOrder';
 
 function PlayPageContent() {
     const searchParams = useSearchParams();
@@ -26,7 +26,9 @@ function PlayPageContent() {
 
     const strategy = (strategyParam === 'random' || strategyParam === 'missedFirst') ? strategyParam : 'random';
     const limit = parseInt(limitParam || '20', 10);
-    const selectedDeckIds = deckIdsParam ? deckIdsParam.split(',').filter(id => id.trim() !== '') : undefined;
+    const selectedDeckIds = useMemo(() => {
+        return deckIdsParam ? deckIdsParam.split(',').filter(id => id.trim() !== '') : undefined;
+    }, [deckIdsParam]);
 
     const orderKeyParams = useMemo<PlayOrderKey>(() => ({
         strategy,
@@ -41,17 +43,17 @@ function PlayPageContent() {
         enabled: !isLoadingAuth && !!token,
     });
 
-    const createReviewMutation = useCreateReviewEventMutation();
-
-    const [currentCardIndex, setCurrentCardIndex] = useState<number>(0);
-    const [reviewSequence, setReviewSequence] = useState<Card[]>([]);
-
     const desiredCardIndexFromParam = useMemo(() => {
         if (!cardParamRaw) return 0;
         const parsed = parseInt(cardParamRaw, 10);
         if (isNaN(parsed) || parsed < 1) return 0;
         return parsed - 1;
     }, [cardParamRaw]);
+
+    const createReviewMutation = useCreateReviewEventMutation();
+
+    const [currentCardIndex, setCurrentCardIndex] = useState<number>(desiredCardIndexFromParam);
+    const [reviewSequence, setReviewSequence] = useState<Card[]>([]);
 
     useEffect(() => {
         if (cards && cards.length > 0) {
@@ -64,21 +66,15 @@ function PlayPageContent() {
 
     useEffect(() => {
         if (reviewSequence.length === 0) return;
-        const normalizedIndex = Math.max(0, Math.min(reviewSequence.length - 1, desiredCardIndexFromParam));
+        const normalizedIndex = Math.max(0, Math.min(reviewSequence.length, desiredCardIndexFromParam));
         setCurrentCardIndex(prev => (prev === normalizedIndex ? prev : normalizedIndex));
-    }, [desiredCardIndexFromParam, reviewSequence]);
-
-    useEffect(() => {
-        if (reviewSequence.length === 0) return;
-        const totalCards = reviewSequence.length;
-        const currentCardNumber = Math.min(currentCardIndex + 1, totalCards);
-        const nextCardParam = String(currentCardNumber);
-        if (cardParamRaw === nextCardParam) return;
+        const normalizedCardParam = String(normalizedIndex + 1);
+        if (cardParamRaw === normalizedCardParam) return;
 
         const p = new URLSearchParams(searchParams.toString());
-        p.set('card', nextCardParam);
+        p.set('card', normalizedCardParam);
         router.replace(`${pathname}?${p.toString()}`, { scroll: false });
-    }, [cardParamRaw, currentCardIndex, reviewSequence.length, router, pathname, searchParams]);
+    }, [cardParamRaw, desiredCardIndexFromParam, reviewSequence.length, router, pathname, searchParams]);
 
     const handleReview = (data: AnswerData) => {
         if (reviewSequence.length === 0 || createReviewMutation.isPending) return;
@@ -95,7 +91,12 @@ function PlayPageContent() {
             user_answer: data.user_answer,
         }, {
             onSuccess: () => {
-                setCurrentCardIndex(currentCardIndex + 1);
+                const nextCardIndex = currentCardIndex + 1;
+                setCurrentCardIndex(nextCardIndex);
+
+                const p = new URLSearchParams(searchParams.toString());
+                p.set('card', String(nextCardIndex + 1));
+                router.replace(`${pathname}?${p.toString()}`, { scroll: false });
             },
             onError: (err) => {
                 alert(`Failed to record review: ${err.message}`);


### PR DESCRIPTION
## Summary

- Start single-deck play sessions with a fresh session identifier in the URL so each new play-through gets a new randomized order.
- Include the session identifier in persisted play-order keys so browser refreshes keep the same shuffled sequence and card index.
- Stabilize selected deck IDs on the multi-deck play page and remove an unused import.

## Validation

- `bun run lint` (passes with existing warnings)
- `bun run build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to client-side play routing, localStorage shuffle keys, and review navigation UX with no backend or auth impact.
> 
> **Overview**
> Single-deck play now **assigns a `session` query param** (UUID) on first load and blocks the UI until it is present, so each visit or **Play Again** gets a **new shuffle** while **refresh/back** keeps the same order and progress for that session.
> 
> **`playOrder`** keys in `localStorage` now include **`sessionId`**, so persisted card order is isolated per session instead of per deck/strategy only. **Play Again** on the deck page issues a new session id and calls **`reshuffleAndSave`** with the updated key.
> 
> Both deck and global play pages **tighten URL `card` sync**: index clamping allows the post-deck “finished” index, **`card` updates on successful review** (not only via a separate index-watching effect), and initial index follows the URL param. The global play page **memoizes `deckIds`** from the query string and drops an unused **`reshuffleAndSave`** import (play again still clears order and refetches).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cbd1ffe77fe96d52993bf533066b09f26291662. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->